### PR TITLE
Fix for can't generate controller action with full class path (L5.2)

### DIFF
--- a/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiController.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiController.php
@@ -71,7 +71,7 @@ abstract class JsonApiController extends Controller
         $totalAmount = $this->totalAmountResourceCallable();
         $results = $this->listResourceCallable();
 
-        $controllerAction = '\\'.get_class($this).'@index';
+        $controllerAction = str_ireplace('App\Http\Controllers\\','', get_class($this)).'@index';
         $uri = action($controllerAction, []);
 
         return $this->addHeaders($resource->get($totalAmount, $results, $uri, get_class($this->getDataModel())));


### PR DESCRIPTION
A class path like ```App\Http\Controllers\API\EmployeesController```
can't be resolved to an action in Laravel 5.2. The simple solution
is to remove the namespace from the path.