### PR TITLE
When creating a new resource that has a client generated id we should…

### DIFF
--- a/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiTrait.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiTrait.php
@@ -211,7 +211,7 @@ trait JsonApiTrait
             }
 
             if (!empty($data['id'])) {
-                $model->setAttribute($model->getKeyName(), $values['id']);
+                $model->setAttribute($model->getKeyName(), $data['id']);
             }
 
             try {


### PR DESCRIPTION
… take the id directly from the id property. The spec doesnt say anything about providing the id twice (in data and in atributes section). Fix #31

Signed-off-by: Clemens John <clemens.john@floh1111.de>