### PR TITLE
Fix pagination used default eloquent's page size (fix #76)

### DIFF
--- a/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiTrait.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiTrait.php
@@ -83,7 +83,7 @@ trait JsonApiTrait
     protected function listResourceCallable()
     {
         return function () {
-            return EloquentHelper::paginate($this->serializer, $this->getDataModel()->query())->get();
+            return EloquentHelper::paginate($this->serializer, $this->getDataModel()->query(), $this->pageSize)->get();
         };
     }
 

--- a/src/NilPortugues/Laravel5/JsonApi/Eloquent/EloquentHelper.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Eloquent/EloquentHelper.php
@@ -23,17 +23,18 @@ trait EloquentHelper
     /**
      * @param JsonApiSerializer $serializer
      * @param Builder           $builder
+     * @param int               $pageSize
      *
      * @return Builder
      */
-    public static function paginate(JsonApiSerializer $serializer, Builder $builder)
+    public static function paginate(JsonApiSerializer $serializer, Builder $builder, $pageSize = null)
     {
         self::sort($serializer, $builder, $builder->getModel());
 
         $request = RequestFactory::create();
 
         $builder->paginate(
-            $request->getPage()->size(),
+            $request->getPage()->size() ?: $pageSize,
             self::columns($serializer, $request->getFields()->get()),
             'page',
             $request->getPage()->number()


### PR DESCRIPTION
Fixed `EloquentHelper::paginate` to accept `$pageSize` when called from `JsonApiTrait`.