### PR TITLE
Usability: Easier Copy-Paste from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@
 Use [Composer](https://getcomposer.org) to install the package:
 
 ```
-$ composer require nilportugues/laravel5-json-api
+composer require nilportugues/laravel5-json-api
 ```
 
 Now run the following artisan command: 
 
 ```
-$ php artisan vendor:publish
+php artisan vendor:publish
 ```
 
 ## Configuration (Laravel 5 & Lumen)


### PR DESCRIPTION
Hi, I made this pull request as a suggestion on usability mostly, no harm done if the request is denied.

I just found out about the project and I am super excited to try it. However, I noticed during installation that I had to carefully select what I copy-pasted when I was copy-ing the composer command due to the '$' character at the beginning. This isn't a major deal, but it bugged me enough to offer to change it, if there was desire.

Thanks for reading!
