### PR TITLE
JsonApiController uses default Carbon date format

### DIFF
--- a/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiController.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiController.php
@@ -103,8 +103,8 @@ abstract class JsonApiController extends Controller
         $model = $this->getDataModel();
         $data = (array) $request->get('data');
         if (array_key_exists('attributes', $data) && $model->timestamps) {
-            $data['attributes'][$model::CREATED_AT] = Carbon::now()->toDateTimeString();
-            $data['attributes'][$model::UPDATED_AT] = Carbon::now()->toDateTimeString();
+            $data['attributes'][$model::CREATED_AT] = Carbon::now()->__toString();
+            $data['attributes'][$model::UPDATED_AT] = Carbon::now()->__toString();
         }
 
         return $this->addHeaders(


### PR DESCRIPTION
The old code worked only if you used the default date format in Eloquent models. If you set Eloquent's property `dateFormat` to non-default value, it will not work properly.

Example: `protected $dateFormat = DateTime::ISO8601;`

This pull request will fix the problem.