### PR TITLE
Feature/filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 composer.lock
 build/
 .coveralls.yml
+.settings
+.project
+.buildpath

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,15 @@
     "require": {
         "nilportugues/json-api": "^2.4",
         "symfony/psr-http-message-bridge": "~0.1",
-        "nilportugues/serializer-eloquent": "~1.0"
+        "nilportugues/serializer-eloquent": "~1.0",
+        "xiag/rql-parser": "^2.0"
     },
     "require-dev": {
-        "laravel/laravel": "5.*",
+        "laravel/laravel": "5.2.*",
         "laravel/lumen": "^5.2",
         "phpunit/phpunit": "4.*",
-        "friendsofphp/php-cs-fixer": "^1.10"
+        "friendsofphp/php-cs-fixer": "^1.10",
+        "xiag/rql-command": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiController.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiController.php
@@ -46,19 +46,19 @@ abstract class JsonApiController extends Controller
         $sorting = $apiRequest->getSort();
         $included = $apiRequest->getIncludedRelationships();
         $filters = $apiRequest->getFilters();
-        
+
         //HACK: JsonAPI is specifying this as an array but it should be a string at this point for RQL processing.
-        switch(count($filters)){
-        	case 0:
-        		$filters = null;
-        		break;
-        	case 1:
-        		$filters = $filters[0];
-        		break;
-        	default:
-        		throw new \Exception('Only a single filter is supported at present.');
-        }        
-        
+        switch (count($filters)) {
+            case 0:
+                $filters = null;
+                break;
+            case 1:
+                $filters = $filters[0];
+                break;
+            default:
+                throw new \Exception('Only a single filter is supported at present.');
+        }
+
         $resource = new ListResource($this->serializer, $page, $fields, $sorting, $included, $filters);
 
         $this->createQuery($filters);

--- a/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiController.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiController.php
@@ -46,9 +46,22 @@ abstract class JsonApiController extends Controller
         $sorting = $apiRequest->getSort();
         $included = $apiRequest->getIncludedRelationships();
         $filters = $apiRequest->getFilters();
-
+        
+        //HACK: JsonAPI is specifying this as an array but it should be a string at this point for RQL processing.
+        switch(count($filters)){
+        	case 0:
+        		$filters = null;
+        		break;
+        	case 1:
+        		$filters = $filters[0];
+        		break;
+        	default:
+        		throw new \Exception('Only a single filter is supported at present.');
+        }        
+        
         $resource = new ListResource($this->serializer, $page, $fields, $sorting, $included, $filters);
 
+        $this->createQuery($filters);
         $totalAmount = $this->totalAmountResourceCallable();
         $results = $this->listResourceCallable();
 

--- a/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiTrait.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiTrait.php
@@ -14,17 +14,16 @@ use Carbon\Carbon;
 use Illuminate\Container\Container;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
-use NilPortugues\Laravel5\JsonApi\Actions\PatchResource;
-use NilPortugues\Laravel5\JsonApi\Actions\PutResource;
 use NilPortugues\Api\JsonApi\Server\Errors\Error;
 use NilPortugues\Api\JsonApi\Server\Errors\ErrorBag;
+use NilPortugues\Laravel5\JsonApi\Actions\PatchResource;
+use NilPortugues\Laravel5\JsonApi\Actions\PutResource;
 use NilPortugues\Laravel5\JsonApi\Eloquent\EloquentHelper;
+use NilPortugues\Laravel5\JsonApi\Eloquent\EloquentNodeVisitor;
 use NilPortugues\Laravel5\JsonApi\JsonApiSerializer;
 use Symfony\Component\HttpFoundation\Response;
 use Xiag\Rql\Parser\Lexer;
 use Xiag\Rql\Parser\Parser;
-use NilPortugues\Laravel5\JsonApi\Eloquent\EloquentQueryBuilder;
-use NilPortugues\Laravel5\JsonApi\Eloquent\EloquentNodeVisitor;
 
 trait JsonApiTrait
 {
@@ -37,7 +36,7 @@ trait JsonApiTrait
      * @var int
      */
     protected $pageSize = 10;
-    
+
     /**
      * @var \Illuminate\Database\Eloquent\Builder
      */
@@ -82,30 +81,28 @@ trait JsonApiTrait
      * @return Model
      */
     abstract public function getDataModel();
-    
+
     /**
      * Creates the query to use for obtaining the resources to return.
-     * 
+     *
      * @param array $filter
      */
     protected function createQuery($filter)
     {
-    	$queryBuilder = $this->getDataModel()->query();
-    	
-    	if(isset($filter)){
-    	
-	     	$lexer = new Lexer();
-	 		$parser = new Parser();	 		
-	 		
-	 		$tokens = $lexer->tokenize($filter);
-			$rqlQuery = $parser->parse($tokens);
-		
-	     	$nodeVisitor = new EloquentNodeVisitor();
-	     	$nodeVisitor->visit($rqlQuery, $queryBuilder);	
-    	}
-    	
-    	$this->query = $queryBuilder;
-    
+        $queryBuilder = $this->getDataModel()->query();
+
+        if (isset($filter)) {
+            $lexer = new Lexer();
+            $parser = new Parser();
+
+            $tokens = $lexer->tokenize($filter);
+            $rqlQuery = $parser->parse($tokens);
+
+            $nodeVisitor = new EloquentNodeVisitor();
+            $nodeVisitor->visit($rqlQuery, $queryBuilder);
+        }
+
+        $this->query = $queryBuilder;
     }
 
     /**
@@ -180,6 +177,7 @@ trait JsonApiTrait
     /**
      * @param Request $request
      * @param $id
+     *
      * @return Response
      */
     protected function putAction(Request $request, $id)
@@ -221,6 +219,7 @@ trait JsonApiTrait
     /**
      * @param Request $request
      * @param $id
+     *
      * @return Response
      */
     protected function patchAction(Request $request, $id)
@@ -235,7 +234,7 @@ trait JsonApiTrait
         if (array_key_exists('attributes', $data) && $model->timestamps) {
             $data['attributes'][$model::UPDATED_AT] = Carbon::now()->toDateTimeString();
         }
-        
+
         return $this->addHeaders(
             $resource->get($id, $data, get_class($model), $find, $update)
         );

--- a/src/NilPortugues/Laravel5/JsonApi/Eloquent/EloquentNodeVisitor.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Eloquent/EloquentNodeVisitor.php
@@ -1,0 +1,157 @@
+<?php
+namespace NilPortugues\Laravel5\JsonApi\Eloquent;
+
+use Xiag\Rql\Parser\Query;
+use Illuminate\Database\Eloquent\Builder;
+use Xiag\Rql\Parser\Node\AbstractQueryNode;
+use Xiag\Rql\Parser\Node\Query\AbstractScalarOperatorNode;
+use Xiag\Rql\Parser\Node\Query\AbstractArrayOperatorNode;
+use Xiag\Rql\Parser\Node\Query\AbstractLogicalOperatorNode;
+use Xiag\Rql\Parser\Glob;
+
+/**
+ * RQL node visitor for constructing Eloquent queries.
+ * 
+ * @author srottem
+ *
+ */
+class EloquentNodeVisitor
+{
+	/**
+	 * Populates the provided builder from the provided RQL query instance.
+	 * 
+	 * @param Query $query		The RQL query to populate the Eloquent builder from.
+	 * @param Builder $builder	The Eloquent query builder to populate.
+	 */
+	public function visit(Query $query, Builder $builder)
+	{		
+		if ($query->getQuery() !== null) {
+			$this->visitQueryNode($query->getQuery(), $builder);
+		}
+	}
+
+	/**
+	 * Processes a query node.
+	 * 
+	 * @param AbstractQueryNode $node	The node to process.
+	 * @param Builder $builder			The Eloquent builder to populate.
+	 * @param string $operator			The operator to use when appending where clauses
+	 * @throws \LogicException			Thrown if the node is of an unknown type.
+	 */
+	private function visitQueryNode(AbstractQueryNode $node, Builder $builder, $operator = 'and')
+	{
+		if ($node instanceof AbstractScalarOperatorNode) {
+			$this->visitScalarNode($node, $builder, $operator);
+		} elseif ($node instanceof AbstractArrayOperatorNode) {
+			$this->visitArrayNode($node, $builder, $operator);
+		} elseif ($node instanceof AbstractLogicalOperatorNode) {
+			$this->visitLogicalNode($node, $builder, $operator);
+		} else {
+			throw new \LogicException(sprintf('Unknown node "%s"', $node->getNodeName()));
+		}
+	}
+	
+	/**
+	 * Processes a scalar node.
+	 * 
+	 * @param AbstractScalarOperatorNode $node	The node to process.
+	 * @param Builder $builder					The Eloquent builder to populate.
+	 * @param unknown $operator					The operator to use when appending where clauses.
+	 * @throws \LogicException					Thrown if the node cannot be processed.
+	 */
+	private function visitScalarNode(AbstractScalarOperatorNode $node, Builder $builder, $operator)
+	{
+		static $operators = [
+			'like'  => 'LIKE',
+			'eq'    => '=',
+			'ne'    => '<>',
+			'lt'    => '<',
+			'gt'    => '>',
+			'le'    => '<=',
+			'ge'    => '>=',
+		];
+		
+		if (!isset($operators[$node->getNodeName()])) {
+			throw new \LogicException(sprintf('Unknown scalar node "%s"', $node->getNodeName()));
+		}
+		
+		$value = $node->getValue();
+		
+		if ($value instanceof Glob) {
+			$value = $value->toLike();
+		} elseif ($value instanceof \DateTimeInterface) {
+			$value = $value->format(DATE_ISO8601);
+		}
+		
+		if($value === null){
+			if($node->getNodeName() === 'eq'){
+				$builder->whereNull($node->getField(), $operator);
+			} elseif($node->getNodeName() === 'ne'){
+				$builder->whereNotNull($node->getField(), $operator);
+			} else {
+				throw new \LogicException(sprintf("Only the 'eq' an 'ne' operators can be used when comparing to 'null()'."));
+			}
+		} else {
+			$builder->where(
+				$node->getField(),
+				$operators[$node->getNodeName()],
+				$value,
+				$operator
+			);
+		}
+	}
+	
+	/**
+	 * Processes an array node.
+	 * 
+	 * @param AbstractArrayOperatorNode $node	The node to process.
+	 * @param Builder $builder					The Eloquent builder to populate.
+	 * @param unknown $operator					The operator to use when appending where clauses.
+	 * @throws \LogicException					Thrown if the node cannot be processed.
+	 */
+	private function visitArrayNode(AbstractArrayOperatorNode $node, Builder $builder, $operator)
+	{
+		static $operators = [
+            'in',
+            'out',
+        ];
+	
+		if(!in_array($node->getNodeName(), $operators)){
+			throw new \LogicException(sprintf('Unknown array node "%s"', $node->getNodeName()));
+		}
+	
+		$negate = false;
+		
+		if($node->getNodeName() === 'out'){
+			$negate = true;
+		}
+
+		$builder->whereIn(
+			$node->getField(),
+			$node->getValues(),
+			$operator,
+			$negate
+		);
+	}
+	
+	/**
+	 * Processes a logical node.
+	 * 
+	 * @param AbstractLogicalOperatorNode $node	The node to process.
+	 * @param Builder $builder					The Eloquent builder to populate.
+	 * @param unknown $operator					The operator to use when appending where clauses.
+	 * @throws \LogicException					Thrown if the node cannot be processed.
+	 */
+	private function visitLogicalNode(AbstractLogicalOperatorNode $node, Builder $builder, $operator)
+	{
+		if ($node->getNodeName() !== 'and' && $node->getNodeName() !== 'or') {
+			throw new \LogicException(sprintf('Unknown or unsupported logical node "%s"', $node->getNodeName()));
+		}		
+		
+		$builder->where(\Closure::bind(function($constraintGroupBuilder) use($node) {
+			foreach ($node->getQueries() as $query) {
+				$this->visitQueryNode($query, $constraintGroupBuilder, $node->getNodeName());
+			}		
+		}, $this), null, null, $operator);		
+	}
+}

--- a/src/NilPortugues/Laravel5/JsonApi/Eloquent/EloquentNodeVisitor.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Eloquent/EloquentNodeVisitor.php
@@ -1,157 +1,161 @@
 <?php
+
 namespace NilPortugues\Laravel5\JsonApi\Eloquent;
 
-use Xiag\Rql\Parser\Query;
 use Illuminate\Database\Eloquent\Builder;
+use Xiag\Rql\Parser\Glob;
 use Xiag\Rql\Parser\Node\AbstractQueryNode;
-use Xiag\Rql\Parser\Node\Query\AbstractScalarOperatorNode;
 use Xiag\Rql\Parser\Node\Query\AbstractArrayOperatorNode;
 use Xiag\Rql\Parser\Node\Query\AbstractLogicalOperatorNode;
-use Xiag\Rql\Parser\Glob;
+use Xiag\Rql\Parser\Node\Query\AbstractScalarOperatorNode;
+use Xiag\Rql\Parser\Query;
 
 /**
  * RQL node visitor for constructing Eloquent queries.
- * 
- * @author srottem
  *
+ * @author srottem
  */
 class EloquentNodeVisitor
 {
-	/**
-	 * Populates the provided builder from the provided RQL query instance.
-	 * 
-	 * @param Query $query		The RQL query to populate the Eloquent builder from.
-	 * @param Builder $builder	The Eloquent query builder to populate.
-	 */
-	public function visit(Query $query, Builder $builder)
-	{		
-		if ($query->getQuery() !== null) {
-			$this->visitQueryNode($query->getQuery(), $builder);
-		}
-	}
+    /**
+     * Populates the provided builder from the provided RQL query instance.
+     *
+     * @param Query   $query   The RQL query to populate the Eloquent builder from
+     * @param Builder $builder The Eloquent query builder to populate
+     */
+    public function visit(Query $query, Builder $builder)
+    {
+        if ($query->getQuery() !== null) {
+            $this->visitQueryNode($query->getQuery(), $builder);
+        }
+    }
 
-	/**
-	 * Processes a query node.
-	 * 
-	 * @param AbstractQueryNode $node	The node to process.
-	 * @param Builder $builder			The Eloquent builder to populate.
-	 * @param string $operator			The operator to use when appending where clauses
-	 * @throws \LogicException			Thrown if the node is of an unknown type.
-	 */
-	private function visitQueryNode(AbstractQueryNode $node, Builder $builder, $operator = 'and')
-	{
-		if ($node instanceof AbstractScalarOperatorNode) {
-			$this->visitScalarNode($node, $builder, $operator);
-		} elseif ($node instanceof AbstractArrayOperatorNode) {
-			$this->visitArrayNode($node, $builder, $operator);
-		} elseif ($node instanceof AbstractLogicalOperatorNode) {
-			$this->visitLogicalNode($node, $builder, $operator);
-		} else {
-			throw new \LogicException(sprintf('Unknown node "%s"', $node->getNodeName()));
-		}
-	}
-	
-	/**
-	 * Processes a scalar node.
-	 * 
-	 * @param AbstractScalarOperatorNode $node	The node to process.
-	 * @param Builder $builder					The Eloquent builder to populate.
-	 * @param unknown $operator					The operator to use when appending where clauses.
-	 * @throws \LogicException					Thrown if the node cannot be processed.
-	 */
-	private function visitScalarNode(AbstractScalarOperatorNode $node, Builder $builder, $operator)
-	{
-		static $operators = [
-			'like'  => 'LIKE',
-			'eq'    => '=',
-			'ne'    => '<>',
-			'lt'    => '<',
-			'gt'    => '>',
-			'le'    => '<=',
-			'ge'    => '>=',
-		];
-		
-		if (!isset($operators[$node->getNodeName()])) {
-			throw new \LogicException(sprintf('Unknown scalar node "%s"', $node->getNodeName()));
-		}
-		
-		$value = $node->getValue();
-		
-		if ($value instanceof Glob) {
-			$value = $value->toLike();
-		} elseif ($value instanceof \DateTimeInterface) {
-			$value = $value->format(DATE_ISO8601);
-		}
-		
-		if($value === null){
-			if($node->getNodeName() === 'eq'){
-				$builder->whereNull($node->getField(), $operator);
-			} elseif($node->getNodeName() === 'ne'){
-				$builder->whereNotNull($node->getField(), $operator);
-			} else {
-				throw new \LogicException(sprintf("Only the 'eq' an 'ne' operators can be used when comparing to 'null()'."));
-			}
-		} else {
-			$builder->where(
-				$node->getField(),
-				$operators[$node->getNodeName()],
-				$value,
-				$operator
-			);
-		}
-	}
-	
-	/**
-	 * Processes an array node.
-	 * 
-	 * @param AbstractArrayOperatorNode $node	The node to process.
-	 * @param Builder $builder					The Eloquent builder to populate.
-	 * @param unknown $operator					The operator to use when appending where clauses.
-	 * @throws \LogicException					Thrown if the node cannot be processed.
-	 */
-	private function visitArrayNode(AbstractArrayOperatorNode $node, Builder $builder, $operator)
-	{
-		static $operators = [
+    /**
+     * Processes a query node.
+     *
+     * @param AbstractQueryNode $node     The node to process
+     * @param Builder           $builder  The Eloquent builder to populate
+     * @param string            $operator The operator to use when appending where clauses
+     *
+     * @throws \LogicException Thrown if the node is of an unknown type
+     */
+    private function visitQueryNode(AbstractQueryNode $node, Builder $builder, $operator = 'and')
+    {
+        if ($node instanceof AbstractScalarOperatorNode) {
+            $this->visitScalarNode($node, $builder, $operator);
+        } elseif ($node instanceof AbstractArrayOperatorNode) {
+            $this->visitArrayNode($node, $builder, $operator);
+        } elseif ($node instanceof AbstractLogicalOperatorNode) {
+            $this->visitLogicalNode($node, $builder, $operator);
+        } else {
+            throw new \LogicException(sprintf('Unknown node "%s"', $node->getNodeName()));
+        }
+    }
+
+    /**
+     * Processes a scalar node.
+     *
+     * @param AbstractScalarOperatorNode $node     The node to process
+     * @param Builder                    $builder  The Eloquent builder to populate
+     * @param unknown                    $operator The operator to use when appending where clauses
+     *
+     * @throws \LogicException Thrown if the node cannot be processed
+     */
+    private function visitScalarNode(AbstractScalarOperatorNode $node, Builder $builder, $operator)
+    {
+        static $operators = [
+            'like' => 'LIKE',
+            'eq' => '=',
+            'ne' => '<>',
+            'lt' => '<',
+            'gt' => '>',
+            'le' => '<=',
+            'ge' => '>=',
+        ];
+
+        if (!isset($operators[$node->getNodeName()])) {
+            throw new \LogicException(sprintf('Unknown scalar node "%s"', $node->getNodeName()));
+        }
+
+        $value = $node->getValue();
+
+        if ($value instanceof Glob) {
+            $value = $value->toLike();
+        } elseif ($value instanceof \DateTimeInterface) {
+            $value = $value->format(DATE_ISO8601);
+        }
+
+        if ($value === null) {
+            if ($node->getNodeName() === 'eq') {
+                $builder->whereNull($node->getField(), $operator);
+            } elseif ($node->getNodeName() === 'ne') {
+                $builder->whereNotNull($node->getField(), $operator);
+            } else {
+                throw new \LogicException(sprintf("Only the 'eq' an 'ne' operators can be used when comparing to 'null()'."));
+            }
+        } else {
+            $builder->where(
+                $node->getField(),
+                $operators[$node->getNodeName()],
+                $value,
+                $operator
+            );
+        }
+    }
+
+    /**
+     * Processes an array node.
+     *
+     * @param AbstractArrayOperatorNode $node     The node to process
+     * @param Builder                   $builder  The Eloquent builder to populate
+     * @param unknown                   $operator The operator to use when appending where clauses
+     *
+     * @throws \LogicException Thrown if the node cannot be processed
+     */
+    private function visitArrayNode(AbstractArrayOperatorNode $node, Builder $builder, $operator)
+    {
+        static $operators = [
             'in',
             'out',
         ];
-	
-		if(!in_array($node->getNodeName(), $operators)){
-			throw new \LogicException(sprintf('Unknown array node "%s"', $node->getNodeName()));
-		}
-	
-		$negate = false;
-		
-		if($node->getNodeName() === 'out'){
-			$negate = true;
-		}
 
-		$builder->whereIn(
-			$node->getField(),
-			$node->getValues(),
-			$operator,
-			$negate
-		);
-	}
-	
-	/**
-	 * Processes a logical node.
-	 * 
-	 * @param AbstractLogicalOperatorNode $node	The node to process.
-	 * @param Builder $builder					The Eloquent builder to populate.
-	 * @param unknown $operator					The operator to use when appending where clauses.
-	 * @throws \LogicException					Thrown if the node cannot be processed.
-	 */
-	private function visitLogicalNode(AbstractLogicalOperatorNode $node, Builder $builder, $operator)
-	{
-		if ($node->getNodeName() !== 'and' && $node->getNodeName() !== 'or') {
-			throw new \LogicException(sprintf('Unknown or unsupported logical node "%s"', $node->getNodeName()));
-		}		
-		
-		$builder->where(\Closure::bind(function($constraintGroupBuilder) use($node) {
-			foreach ($node->getQueries() as $query) {
-				$this->visitQueryNode($query, $constraintGroupBuilder, $node->getNodeName());
-			}		
-		}, $this), null, null, $operator);		
-	}
+        if (!in_array($node->getNodeName(), $operators)) {
+            throw new \LogicException(sprintf('Unknown array node "%s"', $node->getNodeName()));
+        }
+
+        $negate = false;
+
+        if ($node->getNodeName() === 'out') {
+            $negate = true;
+        }
+
+        $builder->whereIn(
+            $node->getField(),
+            $node->getValues(),
+            $operator,
+            $negate
+        );
+    }
+
+    /**
+     * Processes a logical node.
+     *
+     * @param AbstractLogicalOperatorNode $node     The node to process
+     * @param Builder                     $builder  The Eloquent builder to populate
+     * @param unknown                     $operator The operator to use when appending where clauses
+     *
+     * @throws \LogicException Thrown if the node cannot be processed
+     */
+    private function visitLogicalNode(AbstractLogicalOperatorNode $node, Builder $builder, $operator)
+    {
+        if ($node->getNodeName() !== 'and' && $node->getNodeName() !== 'or') {
+            throw new \LogicException(sprintf('Unknown or unsupported logical node "%s"', $node->getNodeName()));
+        }
+
+        $builder->where(\Closure::bind(function ($constraintGroupBuilder) use ($node) {
+            foreach ($node->getQueries() as $query) {
+                $this->visitQueryNode($query, $constraintGroupBuilder, $node->getNodeName());
+            }
+        }, $this), null, null, $operator);
+    }
 }

--- a/tests/NilPortugues/App/Controller/EmployeesController.php
+++ b/tests/NilPortugues/App/Controller/EmployeesController.php
@@ -136,6 +136,18 @@ class EmployeesController extends JsonApiController
         $sorting = $apiRequest->getSort();
         $included = $apiRequest->getIncludedRelationships();
         $filters = $apiRequest->getFilters();
+        
+        //HACK: JsonAPI is specifying this as an array but it should be a string at this point for RQL processing.
+    	switch(count($filters)){
+        	case 0:
+        		$filters = null;
+        		break;
+        	case 1:
+        		$filters = $filters[0];
+        		break;
+        	default:
+        		throw new \Exception('Only a single filter is supported at present.');
+        }      
 
         $resource = new ListResource($this->serializer, $page, $fields, $sorting, $included, $filters);
 

--- a/tests/NilPortugues/App/Transformers/EmployeesTransformer.php
+++ b/tests/NilPortugues/App/Transformers/EmployeesTransformer.php
@@ -98,4 +98,9 @@ class EmployeesTransformer implements JsonApiMapping
     {
         return [];
     }
+    
+    public function getRequiredProperties()
+    {
+    	return [];
+    }
 }

--- a/tests/NilPortugues/App/Transformers/OrdersTransformer.php
+++ b/tests/NilPortugues/App/Transformers/OrdersTransformer.php
@@ -93,4 +93,9 @@ class OrdersTransformer implements JsonApiMapping
     {
         return [];
     }
+    
+    public function getRequiredProperties()
+    {
+    	return [];
+    }
 }

--- a/tests/NilPortugues/Laravel5/JsonApi/JsonApiControllerTest.php
+++ b/tests/NilPortugues/Laravel5/JsonApi/JsonApiControllerTest.php
@@ -31,7 +31,7 @@ class JsonApiControllerTest extends LaravelTestCase
         $this->assertContains('&sort=-id', $response->getContent());
     }
 
-    public function testListActionCanFilterMembers()
+    public function testListActionCanRetrieveSparseFieldsets()
     {
         $this->call('GET', 'http://localhost/employees?fields[employee]=company,first_name');
         $response = $this->response;
@@ -39,6 +39,16 @@ class JsonApiControllerTest extends LaravelTestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('application/vnd.api+json', $response->headers->get('Content-type'));
         $this->assertContains('&fields[employee]=company,first_name', $response->getContent());
+    }
+    
+    public function testListActionCanFilter()
+    {
+    	$this->call('GET', 'http://localhost/employees?filter=ne(a,b)');
+    	$response = $this->response;
+    
+    	$this->assertEquals(200, $response->getStatusCode());
+    	$this->assertEquals('application/vnd.api+json', $response->headers->get('Content-type'));
+    	$this->assertContains('&filter=ne(a,b)', $response->getContent());
     }
 
     public function testListAction()


### PR DESCRIPTION
Hi Nil,

Let me try this again: I've been working up a filtering scheme that uses RQL in the filter request parameter to populate the eloquent query used by the controller index method with where clauses. For example, the request string could contain something like the following:

filter=and(or(and(like(name,b*),ne(name,bob),like(name,a*)),eq(size,10))

There are other ways of expressing this using RQL, but this will do for an example.  At the moment I'm supporting all the standard scalar checks (eq, gt, ge, lt, le, ne) as well as null checks, array checks (in, out) and the logical 'and' and 'or' operators in groups (not is unsupported because I can't figure out how to map it to an Eloquent query builder).

The implementation I've thrown together is using the xiag-ag/rql-parser (https://github.com/xiag-ag/rql-parser) to parse the content of the filter parameter passed on in the request string and then uses a class I've added named EloquentNodeVisitor to add where clauses to the eloquent query builder.

My implementation does kind of break your approach to handling the filter parameter (based, I assume on the recommendation on the jsonapi website) since I want to have a single RQL filter rather than a filter per field. Since the current implementation of your json-api package exposes the filter through the Request->getFilters and this always returns an array it posed an issue with obtaining the RQL and still getting correctly formed links in the response. As a workaround the JsonApiController now converts the result from getFilters to a string or a null - it might be better to change this in the json-api package instead but I didn't know whether this approach made sense to you so I've just hacked it for now.

Let me know if you want anything further clarified.

Symon.