### PR TITLE
copying controller actions to the LumenJSONAPIController

### DIFF
--- a/src/NilPortugues/Laravel5/JsonApi/Controller/LumenJsonApiController.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Controller/LumenJsonApiController.php
@@ -13,6 +13,17 @@ namespace NilPortugues\Laravel5\JsonApi\Controller;
 use Laravel\Lumen\Application;
 use Laravel\Lumen\Routing\Controller;
 
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Request;
+use NilPortugues\Api\JsonApi\Http\Factory\RequestFactory;
+use NilPortugues\Api\JsonApi\Http\Response\ResourceNotFound;
+use NilPortugues\Laravel5\JsonApi\Actions\CreateResource;
+use NilPortugues\Laravel5\JsonApi\Actions\DeleteResource;
+use NilPortugues\Laravel5\JsonApi\Actions\GetResource;
+use NilPortugues\Laravel5\JsonApi\Actions\ListResource;
+use Symfony\Component\HttpFoundation\Response;
+
 /**
  * Class LumenJsonApiController.
  */
@@ -39,4 +50,116 @@ abstract class LumenJsonApiController extends Controller
             }
         }
     }
+
+
+     /**
+      * Get many resources.
+      *
+      * @return \Symfony\Component\HttpFoundation\Response
+      */
+     public function index()
+     {
+         $apiRequest = RequestFactory::create();
+
+         $page = $apiRequest->getPage();
+         if (!$page->size()) {
+             $page->setSize($this->pageSize);
+         }
+
+         $fields = $apiRequest->getFields();
+         $sorting = $apiRequest->getSort();
+         $included = $apiRequest->getIncludedRelationships();
+         $filters = $apiRequest->getFilters();
+
+         $resource = new ListResource($this->serializer, $page, $fields, $sorting, $included, $filters);
+
+         $totalAmount = $this->totalAmountResourceCallable();
+         $results = $this->listResourceCallable();
+
+         $controllerAction = '\\'.get_called_class().'@index';
+         $uri = $this->uriGenerator($controllerAction);
+
+         return $this->addHeaders($resource->get($totalAmount, $results, $uri, get_class($this->getDataModel())));
+     }
+
+     /**
+      * Get single resource.
+      *
+      * @param $id
+      *
+      * @return \Symfony\Component\HttpFoundation\Response
+      */
+     public function show($id)
+     {
+         $apiRequest = RequestFactory::create();
+
+         $resource = new GetResource(
+             $this->serializer,
+             $apiRequest->getFields(),
+             $apiRequest->getIncludedRelationships()
+         );
+
+         $find = $this->findResourceCallable($id);
+
+         return $this->addHeaders($resource->get($id, get_class($this->getDataModel()), $find));
+     }
+
+     /**
+      * @return ResourceNotFound
+      */
+     public function create()
+     {
+         return new ResourceNotFound();
+     }
+
+     /**
+      * Post Action.
+      *
+      * @param Request $request
+      *
+      * @return \Symfony\Component\HttpFoundation\Response
+      */
+     public function store(Request $request)
+     {
+         $createResource = $this->createResourceCallable();
+         $resource = new CreateResource($this->serializer);
+         return $this->addHeaders(
+           $resource->get((array) $request->get('data'), get_class($this->getDataModel()), $createResource)
+         );
+     }
+
+     /**
+      * @param $id
+      *
+      * @return Response
+      */
+     public function update(Request $request, $id)
+     {
+         return (strtoupper($request->getMethod()) === 'PUT') ? $this->putAction($request,
+             $id) : $this->patchAction($request, $id);
+     }
+
+     /**
+      * @return ResourceNotFound
+      */
+     public function edit()
+     {
+         return new ResourceNotFound();
+     }
+
+     /**
+      * @param $id
+      *
+      * @return Response
+      */
+     public function destroy($id)
+     {
+         $find = $this->findResourceCallable($id);
+
+         $delete = $this->deleteResourceCallable($id);
+
+         $resource = new DeleteResource($this->serializer);
+
+         return $this->addHeaders($resource->get($id, get_class($this->getDataModel()), $find, $delete));
+     }
 }


### PR DESCRIPTION
Hi Folks, 

First of all thanks for the great library 👍  It's always good to see people solving the hard problems so the rest of us don't have to don't have to 😉 

I was trying to get this library to work with lumen (instead of Laravel) and it didn't seem to work. I noticed that things seemed to be pulled out of the JsonApiTrait in this commit https://github.com/nilportugues/laravel5-jsonapi/commit/c96e65f9500b72763c540081f672c1a53bbfc0d8 but they weren't added to the LumenJsonApiController at the same time. 

The changes in this PR work for me when it comes to simple objects using Eloquent with Lumen but it doesn't seem to work with relationships, I will continue that part of the discussion on the issue here https://github.com/nilportugues/php-api-transformer/issues/10 