### PR TITLE
Allow mutator attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 composer.lock
 build/
 .coveralls.yml
+.idea/
+*.iml

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "nilportugues/serializer-eloquent": "~1.0"
     },
     "require-dev": {
-        "laravel/laravel": "5.*",
+        "laravel/laravel": "5.2",
         "laravel/lumen": "^5.2",
         "phpunit/phpunit": "4.*",
         "friendsofphp/php-cs-fixer": "^1.10"

--- a/src/NilPortugues/Laravel5/JsonApi/Mapper/MappingFactory.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Mapper/MappingFactory.php
@@ -46,9 +46,10 @@ class MappingFactory extends \NilPortugues\Api\Mapping\MappingFactory
         return (!empty(self::$eloquentClasses[$className])) ? self::$eloquentClasses[$className] : parent::getClassProperties($className);
     }
 
-    protected static function getMutatedAttributes(Model $model) {
+    protected static function getMutatedAttributes(Model $model)
+    {
         preg_match_all('/(?<=^|;)set([^;]+?)Attribute(;|$)/', implode(';', get_class_methods($model)), $matches);
-        return array_map(function($match) use ($model) {
+        return array_map(function ($match) use ($model) {
             if ($model::$snakeAttributes) {
                 $match = Str::snake($match);
             }

--- a/tests/NilPortugues/App/Models/Employees.php
+++ b/tests/NilPortugues/App/Models/Employees.php
@@ -64,4 +64,9 @@ class Employees extends Model
     {
         return $this->first_name.' '.$this->last_name;
     }
+
+    public function setJobTitleAttribute($value) {
+        $this->attributes['job_title'] = strtoupper($value);
+
+    }
 }

--- a/tests/NilPortugues/App/Models/Employees.php
+++ b/tests/NilPortugues/App/Models/Employees.php
@@ -65,7 +65,8 @@ class Employees extends Model
         return $this->first_name.' '.$this->last_name;
     }
 
-    public function setJobTitleAttribute($value) {
+    public function setJobTitleAttribute($value)
+    {
         $this->attributes['job_title'] = strtoupper($value);
 
     }

--- a/tests/NilPortugues/App/Transformers/EmployeesTransformer.php
+++ b/tests/NilPortugues/App/Transformers/EmployeesTransformer.php
@@ -104,7 +104,8 @@ class EmployeesTransformer implements JsonApiMapping
      *
      * @return array
      */
-    public function getRequiredProperties() {
+    public function getRequiredProperties()
+    {
         return [];
     }
 }

--- a/tests/NilPortugues/App/Transformers/EmployeesTransformer.php
+++ b/tests/NilPortugues/App/Transformers/EmployeesTransformer.php
@@ -98,4 +98,13 @@ class EmployeesTransformer implements JsonApiMapping
     {
         return [];
     }
+
+    /**
+     * Returns an array of properties that are mandatory to be passed in when doing create or update.
+     *
+     * @return array
+     */
+    public function getRequiredProperties() {
+        return [];
+    }
 }

--- a/tests/NilPortugues/App/Transformers/OrdersTransformer.php
+++ b/tests/NilPortugues/App/Transformers/OrdersTransformer.php
@@ -99,7 +99,8 @@ class OrdersTransformer implements JsonApiMapping
      *
      * @return array
      */
-    public function getRequiredProperties() {
+    public function getRequiredProperties()
+    {
         return [];
     }
 }

--- a/tests/NilPortugues/App/Transformers/OrdersTransformer.php
+++ b/tests/NilPortugues/App/Transformers/OrdersTransformer.php
@@ -93,4 +93,13 @@ class OrdersTransformer implements JsonApiMapping
     {
         return [];
     }
+
+    /**
+     * Returns an array of properties that are mandatory to be passed in when doing create or update.
+     *
+     * @return array
+     */
+    public function getRequiredProperties() {
+        return [];
+    }
 }

--- a/tests/NilPortugues/Laravel5/JsonApi/JsonApiControllerTest.php
+++ b/tests/NilPortugues/Laravel5/JsonApi/JsonApiControllerTest.php
@@ -176,6 +176,8 @@ JSON;
         $this->assertEquals(201, $response->getStatusCode());
         $this->assertEquals('application/vnd.api+json', $response->headers->get('Content-type'));
         $this->assertEquals('http://localhost/employees/1', $response->headers->get('Location'));
+        $content = json_decode($response->getContent());
+        $this->assertEquals('WEB DEVELOPER', $content->data->attributes->job_title);
     }
 
     public function testPostActionCreateNonexistentTypeAndReturnErrors()


### PR DESCRIPTION
To enable server-side processing of attribute values, [Eloquent mutators](https://laravel.com/docs/5.2/eloquent-mutators#accessors-and-mutators) could be used. To enable them for e.g. relationships they have to be included in the class properties. This pull request adds them to the mapping.
