### PR TITLE
Set Carbon to use model specified dateFormat 

### DIFF
--- a/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiTrait.php
+++ b/src/NilPortugues/Laravel5/JsonApi/Controller/JsonApiTrait.php
@@ -160,7 +160,7 @@ trait JsonApiTrait
         $model = $this->getDataModel();
         $data = (array) $request->get('data');
         if (array_key_exists('attributes', $data) && $model->timestamps) {
-            $data['attributes'][$model::UPDATED_AT] = Carbon::now()->toDateTimeString();
+            $data['attributes'][$model::UPDATED_AT] = Carbon::now()->format($model::getDateFormat());
         }
 
         return $this->addHeaders(
@@ -202,7 +202,7 @@ trait JsonApiTrait
         $model = $this->getDataModel();
         $data = (array) $request->get('data');
         if (array_key_exists('attributes', $data) && $model->timestamps) {
-            $data['attributes'][$model::UPDATED_AT] = Carbon::now()->toDateTimeString();
+            $data['attributes'][$model::UPDATED_AT] = Carbon::now()->format($model::getDateFormat());
         }
         
         return $this->addHeaders(


### PR DESCRIPTION
Set Carbon to use model specificed dateFormat for UPDATED_AT fields on put/patch operations.